### PR TITLE
Support adding maps via $ref under additionaProperties as per spec

### DIFF
--- a/jsonschema.go
+++ b/jsonschema.go
@@ -139,6 +139,22 @@ func convertItems(api *openapi2proto.APIDefinition, itemName string, items *open
 
 	// Maintain a list of required items:
 	if definitionJSONSchema.Type == gojsonschema.TYPE_OBJECT {
+
+		// if we have any nested items in the object then we should process
+		// them
+		if item := items.AdditionalProperties; item != nil {
+			var schema jsonschema.Type
+			var raw json.RawMessage
+			schema, err = convertItems(api, item.Name, item)
+
+			// Annoyingly since "additionalProperties" can actually be a
+			// boolean or an object we have to marshal the resulting schema
+			// so we can assign the raw bytes to back
+			raw, err = json.Marshal(schema)
+			definitionJSONSchema.AdditionalProperties = raw
+			return
+		}
+
 		definitionJSONSchema.Required = buildRequiredPropertiesList(requiredProperties)
 	}
 

--- a/jsonschema_test.go
+++ b/jsonschema_test.go
@@ -225,6 +225,39 @@ func Test_GenerateJSONSchemas_ReferencedObject(t *testing.T) {
         "user_name"
     ],
     "properties": {
+        "contact_additional_props_map": {
+            "additionalProperties": {
+                "required": [
+                    "email_address"
+                ],
+                "properties": {
+                    "email_address": {
+                        "additionalProperties": true,
+                        "type": "string"
+                    },
+                    "first_name": {
+                        "additionalProperties": true,
+                        "type": "string"
+                    },
+                    "last_name": {
+                        "additionalProperties": true,
+                        "type": "string"
+                    },
+                    "phone_number": {
+                        "additionalProperties": true,
+                        "type": "string"
+                    },
+                    "spam": {
+                        "additionalProperties": true,
+                        "type": "boolean",
+                        "description": "Send this person spam?"
+                    }
+                },
+                "additionalProperties": true,
+                "type": "object"
+            },
+            "type": "object"
+        },
         "contact_ref": {
             "required": [
                 "email_address"

--- a/sample/swagger2_referenced-object.yaml
+++ b/sample/swagger2_referenced-object.yaml
@@ -25,6 +25,10 @@ definitions:
         type: object
         schema:
           $ref: '#/definitions/ReferencedObject'
+      contact_additional_props_map:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/ReferencedObject'
 
   ReferencedObject:
     type: object


### PR DESCRIPTION
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#model-with-mapdictionary-properties

```
go test -v ./...
=== RUN   Test_GenerateJSONSchemas_FlatObject
2018/03/26 14:17:28 [INFO] Processing schema-definition: FlatObject
--- PASS: Test_GenerateJSONSchemas_FlatObject (0.00s)
=== RUN   Test_GenerateJSONSchemas_FlatObjectWithEnum
2018/03/26 14:17:28 [INFO] Processing schema-definition: FlatObjectWithEnum
--- PASS: Test_GenerateJSONSchemas_FlatObjectWithEnum (0.00s)
=== RUN   Test_GenerateJSONSchemas_ObjectWithArrays
2018/03/26 14:17:28 [INFO] Processing schema-definition: ObjectWithArrays
2018/03/26 14:17:28 [INFO] Processing schema-definition: ReferencedArrayObject
--- PASS: Test_GenerateJSONSchemas_ObjectWithArrays (0.00s)
=== RUN   Test_GenerateJSONSchemas_ObjectWithPattern
2018/03/26 14:17:28 [INFO] Processing schema-definition: ObjectWithPattern
--- PASS: Test_GenerateJSONSchemas_ObjectWithPattern (0.00s)
=== RUN   Test_GenerateJSONSchemas_ReferencedObject
2018/03/26 14:17:28 [INFO] Processing schema-definition: ObjectWithReferencedObject
2018/03/26 14:17:28 [INFO] Processing schema-definition: ReferencedObject
--- PASS: Test_GenerateJSONSchemas_ReferencedObject (0.00s)
PASS
ok      github.com/splunkcloud/openapi2jsonschema       (cached)
```